### PR TITLE
The PHP version has been upgraded to allow the use of getType.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,11 +15,11 @@
         }
     },
     "require": {
-        "php": ">=7.1",
+        "php": "^7.4 || ^8.0",
         "ext-json": "*"
     },
     "require-dev": {
-        "phpunit/phpunit": ">=7.0"
+        "phpunit/phpunit": "^8.3 || ^9.1"
     },
     "scripts": {
         "test": "phpunit ./tests"

--- a/src/PropertyReflector.php
+++ b/src/PropertyReflector.php
@@ -25,24 +25,24 @@ abstract class PropertyReflector
             if (!in_array($key, $properties)) {
                 continue;
             }
-            $reflectionType = $reflection->getProperty($key);
+            $reflectionType = $reflection->getProperty($key)->getType();
 
-            if (!$reflectionType->getName()) {
+            if (!$reflectionType) {
                 $this->$key = $value;
                 continue;
             }
+
             $propertyType = $reflectionType->getName();
+            if ($reflectionType->isBuiltin()) {
+                $tmp_value = $vars;
+                try {
+                    settype($tmp_value, $propertyType);
+                    $this->$key = $tmp_value;
+                    continue;
+                } catch (Throwable $t) {}
+            }
 
             try {
-                if ($reflectionType->isBuiltin()) {
-                    $tmp_value = $vars;
-                    if (settype($tmp_value, $propertyType)) {
-                        $this->$key = $tmp_value;
-                        continue;
-                    }
-                    $this->$key = $value;
-                    continue;
-                }
                 $this->$key = new $propertyType($value);
             } catch (Throwable $t) {
                 $this->$key = $value;

--- a/tests/PropertyReflectorTest.php
+++ b/tests/PropertyReflectorTest.php
@@ -69,4 +69,13 @@ class PropertyReflectorTest extends TestCase
 
         $this->assertNull($user->getName());
     }
+
+    public function test_should_create_named_property()
+    {
+        // created_at property is DateTime
+        $user = new GithubUser($this->json);
+
+        $this->assertNotNull($user->created_at);
+        $this->assertTrue($user->created_at instanceof \DateTime);
+    }
 }

--- a/tests/Resources/GithubUser.php
+++ b/tests/Resources/GithubUser.php
@@ -8,6 +8,7 @@ class GithubUser extends PropertyReflector
 {
     public $id;
     public $login;
+    public \DateTime $created_at;
     public $testProperty;
     protected $node_id;
     protected $avatar_url;


### PR DESCRIPTION
Using the type property causes an error in udenfined.
The getName method returns the property name, which is not the expected behavior.

Therefore, we have changed the PHP version to 7.4 or higher so that type properties can be used.
